### PR TITLE
Disable Public IPs for microservices

### DIFF
--- a/cfn/micro-service.template
+++ b/cfn/micro-service.template
@@ -309,7 +309,7 @@ Resources:
         MinimumHealthyPercent:       0
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp:            ENABLED
+          AssignPublicIp:            DISABLED
           SecurityGroups:
             - !Ref ContainerSG
           Subnets:
@@ -334,7 +334,7 @@ Resources:
         MinimumHealthyPercent:       0
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp:            ENABLED
+          AssignPublicIp:            DISABLED
           SecurityGroups:
             - !Ref ContainerSG
           Subnets:


### PR DESCRIPTION
Since microservices are communicating internally and public-facing ones
are behind a load-balancer, adding public IPs is unnecessary.